### PR TITLE
Fallback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,29 @@ injected area with the indent of the first line of the injection.
 be a table of filetypes that it should not format as an injected language. The
 example will for example not format Rust regions in a markdown file.
 
+### Fallback support
+
+There is a special syntax for fallback, if you for example want to run `sed` to remove all trailing white space
+in the buffer. This is an example of how you can do that
+
+```lua
+require('formatter').setup({
+    treesitter = {
+        -- NOTE: This is needed because otherwise it will try to run `sed` for all injected regions in the buffer
+        -- Otherwise it can mess up the file and not insert it properly.
+        -- I am considering making it _never_ be able to run the fallback configuration on injected regions
+        -- but I haven't decided yet
+        disable_injected = {
+            ['*'] = { '_' },
+        },
+
+        filetype = {
+            _ = 'sed s/[[:space:]]*$//',
+        },
+    },
+})
+```
+
 ### Format on save
 
 To enable format on save, you can set an option `format_on_save` to true or a

--- a/README.md
+++ b/README.md
@@ -117,20 +117,14 @@ example will for example not format Rust regions in a markdown file.
 ### Fallback support
 
 There is a special syntax for fallback, if you for example want to run `sed` to remove all trailing white space
-in the buffer. This is an example of how you can do that
+in the buffer. This is an example of how you can do that.
 
 ```lua
 require('formatter').setup({
     treesitter = {
-        -- NOTE: This is needed because otherwise it will try to run `sed` for all injected regions in the buffer
-        -- Otherwise it can mess up the file and not insert it properly.
-        -- I am considering making it _never_ be able to run the fallback configuration on injected regions
-        -- but I haven't decided yet
-        disable_injected = {
-            ['*'] = { '_' },
-        },
-
         filetype = {
+            -- By default, this will only run it on the entire buffer, and not on any injected regions.
+            -- If you want that behavior, you need to configure `disabled_injected` with `*` as key to be an empty table
             _ = 'sed s/[[:space:]]*$//',
         },
     },

--- a/lua/formatter/config.lua
+++ b/lua/formatter/config.lua
@@ -66,7 +66,7 @@ end
 ---@param ft string
 ---@return table<NvimFormatterFiletypeConfig> | nil
 function M.get_ft_configs(bufnr, ft)
-    local f = config.filetype[ft]
+    local f = config.filetype[ft] or config.filetype['_']
     if not f then
         return nil
     end

--- a/lua/formatter/config.lua
+++ b/lua/formatter/config.lua
@@ -23,7 +23,7 @@ local M = {}
 local config = {
     filetype = {},
     format_on_save = false,
-    treesitter = { auto_indent = {}, disable_injected = {} },
+    treesitter = { auto_indent = {}, disable_injected = { ['*'] = { '_' } } },
 }
 
 ---@param opts NvimFormatterConfig

--- a/lua/formatter/format.lua
+++ b/lua/formatter/format.lua
@@ -302,7 +302,11 @@ function Format:get_injected_confs(ft)
         return {}
     end
 
-    local disable_injected = config.get().treesitter.disable_injected[vim.bo[self.bufnr].ft]
+    local resolved_ft = config.get().filetype[ft] and ft or '_'
+
+    local ft_disable_injected = vim.deepcopy(config.get().treesitter.disable_injected[vim.bo[self.bufnr].ft] or {})
+    local global_disable_injected = config.get().treesitter.disable_injected['*'] or {}
+    local disable_injected = vim.list_extend(ft_disable_injected, global_disable_injected)
 
     -- Only try to format an injected language if it is not disabled with
     -- `disable_injected` or if the executable is different. Check the
@@ -310,7 +314,7 @@ function Format:get_injected_confs(ft)
     -- vue-files. Prettier for vue should do the entire file
     return vim.iter(confs)
         :map(function(c)
-            if not contains(disable_injected, ft) and not same_executable(self.confs, c.exe) then
+            if not contains(disable_injected, resolved_ft) and not same_executable(self.confs, c.exe) then
                 return c
             end
         end)


### PR DESCRIPTION
Add a special `filetype` key `_` to work as a "fallback" filetype.

Make it possible to for example configure `sed` to remove trailing whitespaces for buffers that don't have any formatters configured

Things to think about:
- Should it fallback to this if we have configured something but have not installed the formatter?
- Should we make it default and configurable to have it run on injected areas like now?
    - It doesn't work nicely to make the fallback for sed run on injected areas.
    - I cannot really think of any other "formatters" to run as a fallback, but it probably doesn't harm anything if it's configurable like now. However, it should probably at least be default to only run on entire buffer to avoid any weird behavior